### PR TITLE
feat: add counter of dao errors

### DIFF
--- a/internal/api/dao/daoError/dao_error.go
+++ b/internal/api/dao/daoError/dao_error.go
@@ -1,11 +1,15 @@
 package daoerror
 
 import (
+	"strings"
+
 	"github.com/GuillaumeDeconinck/todos-go/pkg/tools"
 )
 
 const INTERNAL_ERROR_CODE = "INTERNAL_ERROR"
 const NOT_FOUND_CODE = "NOT_FOUND"
+
+var nbErrors = 0
 
 type DaoError struct {
 	Code string
@@ -17,6 +21,15 @@ func (err DaoError) Error() string {
 
 func ConvertToDaoError(err error) *DaoError {
 	tools.SugaredLogger.Errorf("Error received %s\n", err)
+
+	if strings.Contains(err.Error(), "FATAL") {
+		nbErrors += 1
+		// Need a way to clean nbErrors like setTimeout in NodeJS
+		if nbErrors > 5 {
+			// Close server ?
+		}
+	}
+
 	Code := INTERNAL_ERROR_CODE
 	return &DaoError{
 		Code: Code,


### PR DESCRIPTION
### Changes
- The api should be terminated if there are too many infra errors (e.g. the connection to the DB is lost). Of course, we depend on Kube or another orchestrator to restart the service
